### PR TITLE
Validate First 3 Posts

### DIFF
--- a/src/Listener/ValidatePost.php
+++ b/src/Listener/ValidatePost.php
@@ -31,7 +31,7 @@ class ValidatePost
     {
         $post = $event->post;
 
-        if ($post->exists || $post->user->groups()->count()) {
+        if ($post->exists || $post->user->comment_count > 3) {
             return;
         }
 


### PR DESCRIPTION
This changes the behavior of Post Validation for the Akismet extension. Currently the system will only check Akismet if the User whom created the Post has no Group. This can be an issue especially when Users are auto-added to groups on Sign-up. This makes it to where the system will check Akismet on the User's first 3 un-approved Posts. If the User has 3 approved Posts the system will not validate their Posts anymore.